### PR TITLE
Update houses.handlebars

### DIFF
--- a/views/houses.handlebars
+++ b/views/houses.handlebars
@@ -71,7 +71,6 @@
                             <option value="{{id}}">{{fname}} {{lname}}</option>
                             {{/each}}
                         </select>
-                        <option value=''>none</option>
                     </div>
 
                     <div class="form-group">


### PR DESCRIPTION
Made "none" disappear from below the Head dropdown selection.